### PR TITLE
 Add .gitmodules file 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rust/ssb-patchql"]
+	path = rust/ssb-patchql
+	url = https://github.com/sunrise-choir/ssb-patchql.git

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Additionally the Android deployment requires the SDK for Android API 21 and the 
 * Do NOT use brew/apt to install the Android SDK/NDK. Download the official version from the website.
 * You may need to accept the Xcode license agreement in order to build: `sudo xcodebuild -license`
 
+## Sub Modules 
+
+Be sure to clone wit --recursive flag, as this repo contains sub modules. For example
+```shell
+git clone --recursive https://github.com/luandro/react-native-patchql.git
+```
+
 ## Building
 
 Both Android and iOS require that the NPM dependencies for React Native be installed locally and the `react-native-cli` globally.


### PR DESCRIPTION
Pretty sure you need the  .gitmodules file in the repo otherwise the submodules don't check out correctly when you do `git clone --recursive` I'm not totally sure (can't tell) what commit/version of ssb-patchql you were up to so for now I've just set it to the sunrise-choir/ssb-patchql HEAD as of now